### PR TITLE
fix a potential load order bug with application_controller

### DIFF
--- a/app/controllers/letter_bomb/mailers_controller.rb
+++ b/app/controllers/letter_bomb/mailers_controller.rb
@@ -1,3 +1,5 @@
+require 'letter_bomb/application_controller'
+
 module LetterBomb
   class MailersController < ApplicationController
     def index


### PR DESCRIPTION
The fix we did on Friday didn't work. According to this http://stackoverflow.com/questions/10042348/rails-3-2-engine-layouts it's potentially a load order issue with _which_ `ApplicationController` is subclassed in the engine, which is insane. Apparently this will help. :neutral_face: 
