### PR TITLE
Pass through raw params

### DIFF
--- a/app/controllers/letter_bomb/mailers_controller.rb
+++ b/app/controllers/letter_bomb/mailers_controller.rb
@@ -12,7 +12,8 @@ module LetterBomb
 
       @action = class_name.constantize.preview_action(
         action_name,
-        format: params[:format]
+        format: params[:format],
+        raw_params: params
       )
 
       respond_to do |format|

--- a/lib/letter_bomb/preview.rb
+++ b/lib/letter_bomb/preview.rb
@@ -2,6 +2,8 @@ require "forwardable"
 
 module LetterBomb
   class Preview
+    attr_reader :raw_params
+
     class << self
       def classes
         preview_filenames.map { |filename| class_from_filename(filename) }
@@ -13,8 +15,11 @@ module LetterBomb
 
       def preview_action(action_name, options={})
         action = nil
+        preview = new
+        preview.instance_variable_set("@raw_params", options[:raw_params])
+
         ActiveRecord::Base.transaction do
-          mail = new.send(action_name)
+          mail = preview.send(action_name)
           action = Action.new(action_name, mail, options)
           raise ActiveRecord::Rollback
         end

--- a/spec/dummy/app/mailers/foo_mailer_preview.rb
+++ b/spec/dummy/app/mailers/foo_mailer_preview.rb
@@ -14,6 +14,22 @@ class FooMailerPreview < LetterBomb::Preview
     end
   end
 
+  def very_good
+    id = raw_params.fetch(:id) { "" }
+    User.create!(name: 'bob')
+
+    Mail.new do
+      text_part do
+        content_type "text/plain"
+        body "this is text with an id of #{id}"
+      end
+      html_part do
+        content_type "text/html"
+        body "this is html with an id of #{id}"
+      end
+    end
+  end
+
   def bad; end
 
   private

--- a/spec/lib/letter_bomb/preview_spec.rb
+++ b/spec/lib/letter_bomb/preview_spec.rb
@@ -27,5 +27,12 @@ describe LetterBomb::Preview do
       expect(action.name).to eq(:good)
       expect(action).to be_a(LetterBomb::Preview::Action)
     end
+
+    it "passes through raw params" do
+      id = "awesome"
+      raw_params = {id: id}
+      action = FooMailerPreview.preview_action(:very_good, {raw_params: raw_params})
+      expect(action.mail.text_part.body).to match(/#{id}/)
+    end
   end
 end

--- a/spec/lib/letter_bomb/preview_spec.rb
+++ b/spec/lib/letter_bomb/preview_spec.rb
@@ -9,7 +9,7 @@ describe LetterBomb::Preview do
 
   describe ".actions" do
     it "returns an alphabetized list of public instance methods" do
-      expect(FooMailerPreview.actions).to eq(['bad', 'good'])
+      expect(FooMailerPreview.actions).to eq(['bad', 'good', 'very_good'])
     end
   end
 


### PR DESCRIPTION
Ability to read request parameters in preview actions.

This opens up interesting use cases - for example dynamically change objects in mail previews based on user supplied parameters.
